### PR TITLE
Update Arcade help channel

### DIFF
--- a/pages/arcade/index.js
+++ b/pages/arcade/index.js
@@ -1770,7 +1770,7 @@ const Arcade = ({
               />
               <FAQ
                 question="I need help!"
-                answer="Get it in the #arcade channel of the [Hack Club Slack](https://hackclub.com/slack). Alternatively, reach out to [arcade@hackclub.com](mailto:arcade@hackclub.com)"
+                answer="Get it in the #arcade-help channel of the [Hack Club Slack](https://hackclub.com/slack). Alternatively, reach out to [arcade@hackclub.com](mailto:arcade@hackclub.com)"
               />
               <FAQ
                 question="My hours aren't counted!"


### PR DESCRIPTION
We don't want #arcade being full of help requests - sends people to the help channel instead.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the FAQ section on the Arcade page to redirect users seeking help from the #arcade channel to the #arcade-help channel in the Hack Club Slack.

* **Enhancements**:
    - Updated the FAQ section to direct users to the #arcade-help channel instead of the #arcade channel for help requests.

<!-- Generated by sourcery-ai[bot]: end summary -->